### PR TITLE
Update UIApplicationLaunchOptionsKey and UIApplicationOpenURLOptionsKey

### DIFF
--- a/Sources/Core/Common/SDKApplicationDelegate.swift
+++ b/Sources/Core/Common/SDKApplicationDelegate.swift
@@ -49,7 +49,7 @@ public final class SDKApplicationDelegate {
   @discardableResult
   public func
     application(_ application: UIApplication,
-                didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+                didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
     return delegate?.application(application, didFinishLaunchingWithOptions: launchOptions) ?? false
   }
 
@@ -93,7 +93,7 @@ public final class SDKApplicationDelegate {
   @discardableResult
   public func application(_ app: UIApplication,
                           open url: URL,
-                          options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+                          options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
     return delegate?.application(app,
                                  open: url,
                                  sourceApplication: options[.sourceApplication] as? String,


### PR DESCRIPTION
Apple had changed some syntax about UIApplication, so I changed the syntax in this file

# Facebook Swift SDK Pull Request

## Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request
