### PR TITLE
Remove the swiftlint_version in the .swiflint.yml file

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,3 @@
-swiftlint_version: 0.26.0
-
 included:
 - Sources
 - Samples


### PR DESCRIPTION
# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Hey there 👋,

This PR should solve #300. With the new release of Swifttlint 0.29.1 a new rule was introduced:

>The lint command now exits with a code of 2 when not using pinned version defined as swiftlint_version in the configuration file.

This new rule would cause a failure when a different version is used. In this PR I removed the pinned version as IMO it would break the build for users not using the pinned version. Another alternative would be to force the users to pin that version 🤔, but IMHO I think removing it is better. 

At the end this PR can be resumed in :

* Remove the swiftlint_version in the .swiflint.yml file.

I thought about upgrading the dependencies in the `Cartfile` but that would break the build with a new issue related to `FBSDKShareKit` so I decided to keep this simple as possible to solve the issue and later we can create a new PR upgrading the `Cartfile `dependencies and solving some deprecations.
