### PR TITLE
Add missing frameworks to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ At a minimum, you'll need to drag & drop the following frameworks from `Carthage
 To use Login with Facebook:
 
 - `FacebookLogin.framework`
+- `FBSDKLoginKit.framework`
 
 To use Share and Send Dialogs
 
 - `FacebookShare.framework`
+- `FBSDKShareKit.framework`
 
 On your application targets' `Build Phases` tab:
 


### PR DESCRIPTION
# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request

Readme fails to mention that FBSDKLoginKit.framework is required to use FacebookLogin.framework, and FBSDKShareKit.framework is required to use FacebookShare.framework.