### PR TITLE
Update use of deprecated ObjC SDK method

### DIFF
--- a/Sources/Core/GraphRequest/GraphRequestConnection.swift
+++ b/Sources/Core/GraphRequest/GraphRequestConnection.swift
@@ -108,8 +108,8 @@ public class GraphRequestConnection {
                      batchParameters: [String: Any]?,
                      completion: Completion<T>? = nil) {
     sdkConnection.add(request.sdkRequest,
-                      completionHandler: completion.map(type(of: self).sdkRequestCompletion),
-                      batchParameters: batchParameters)
+                      batchParameters: batchParameters,
+                      completionHandler: completion.map(type(of: self).sdkRequestCompletion))
   }
 
   /**


### PR DESCRIPTION
# Facebook Swift SDK Pull Request

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Update use of deprecated FBSDKGraphConnection method to the renamed method. Possible cause of issue #324
