### PR TITLE
Introducing Permission enum

### DIFF
--- a/FacebookSwift.xcodeproj/project.pbxproj
+++ b/FacebookSwift.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		811C5E561CFFD4F800E4A925 /* FacebookCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8115C0D81CFE540D001FF33B /* FacebookCore.framework */; };
 		F409967322289D3000F23464 /* AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F409967222289D3000F23464 /* AccessToken.swift */; };
 		F409967522299BE200F23464 /* AccessTokenWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F409967422299BE200F23464 /* AccessTokenWalletTests.swift */; };
+		F4144A10222DAFCD00CB83E0 /* PermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4144A0F222DAFCD00CB83E0 /* PermissionTests.swift */; };
+		F4144A12222DB16C00CB83E0 /* Permission.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4144A11222DB16C00CB83E0 /* Permission.swift */; };
 		F44DB69222299FA10083506E /* AccessTokenWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44DB69122299FA10083506E /* AccessTokenWallet.swift */; };
 		F44DB6942229AB460083506E /* InternalUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44DB6932229AB460083506E /* InternalUtility.swift */; };
 		F44DB6982229AE4C0083506E /* FakeCookieUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44DB6952229ADFB0083506E /* FakeCookieUtility.swift */; };
@@ -87,6 +89,8 @@
 		81654DD61D356E9A006401F1 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		F409967222289D3000F23464 /* AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessToken.swift; sourceTree = "<group>"; };
 		F409967422299BE200F23464 /* AccessTokenWalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenWalletTests.swift; sourceTree = "<group>"; };
+		F4144A0F222DAFCD00CB83E0 /* PermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionTests.swift; sourceTree = "<group>"; };
+		F4144A11222DB16C00CB83E0 /* Permission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Permission.swift; sourceTree = "<group>"; };
 		F44DB69122299FA10083506E /* AccessTokenWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenWallet.swift; sourceTree = "<group>"; };
 		F44DB6932229AB460083506E /* InternalUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalUtility.swift; sourceTree = "<group>"; };
 		F44DB6952229ADFB0083506E /* FakeCookieUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCookieUtility.swift; sourceTree = "<group>"; };
@@ -203,6 +207,7 @@
 				F49FA47A222880FE0008CAD6 /* FacebookCoreTests */,
 				F44DB6992229B36D0083506E /* Needs Conversion */,
 				F44DB6B8222B07740083506E /* GraphConnectionProvider.swift */,
+				F4144A11222DB16C00CB83E0 /* Permission.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -334,6 +339,7 @@
 				F44DB6972229AE040083506E /* Helpers */,
 				F49FA47D222880FE0008CAD6 /* Info.plist */,
 				F45734D6222D9535001F806A /* InternalUtilityTests.swift */,
+				F4144A0F222DAFCD00CB83E0 /* PermissionTests.swift */,
 			);
 			path = FacebookCoreTests;
 			sourceTree = "<group>";
@@ -586,6 +592,7 @@
 				F44DB69D2229B4420083506E /* AccessTokenCaching.swift in Sources */,
 				F409967322289D3000F23464 /* AccessToken.swift in Sources */,
 				F44DB6B1222B01A30083506E /* NotificationName+Extensions.swift in Sources */,
+				F4144A12222DB16C00CB83E0 /* Permission.swift in Sources */,
 				F44DB69B2229B37F0083506E /* Settings.swift in Sources */,
 				F44DB6B7222B07050083506E /* GraphRequestConnection.swift in Sources */,
 				F44DB69F2229B4C50083506E /* AccessTokenCache.swift in Sources */,
@@ -626,6 +633,7 @@
 				F49FA4902228819E0008CAD6 /* AccessTokenTests.swift in Sources */,
 				F44DB6A32229C6B60083506E /* FakeSettings.swift in Sources */,
 				F44DB6A12229C50E0083506E /* FakeAccessTokenCache.swift in Sources */,
+				F4144A10222DAFCD00CB83E0 /* PermissionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Core/AccessToken.swift
+++ b/Sources/Core/AccessToken.swift
@@ -18,9 +18,6 @@
 
 import Foundation
 
-// TODO: Make this an actual type once we have better knowledge of permissions requirements
-typealias Permission = String
-
 ///
 /// Represents an immutable access token for using Facebook services.
 ///

--- a/Sources/Core/FacebookCoreTests/AccessTokenTests.swift
+++ b/Sources/Core/FacebookCoreTests/AccessTokenTests.swift
@@ -38,12 +38,12 @@ class AccessTokenTests: XCTestCase {
 
     let token = AccessToken(
       tokenString: AccessTokenFixtures.validToken.tokenString,
-      permissions: [Permission.email, .firstName],
+      permissions: [Permission.email, .userPosts],
       appID: AccessTokenFixtures.validToken.appID,
       userID: AccessTokenFixtures.validToken.userID
     )
 
-    XCTAssertEqual(token.permissions, [Permission.email, .firstName],
+    XCTAssertEqual(token.permissions, [Permission.email, .userPosts],
                    "An access token should store the exact permissions it was created with")
   }
 
@@ -52,12 +52,12 @@ class AccessTokenTests: XCTestCase {
 
     let token = AccessToken(
       tokenString: AccessTokenFixtures.validToken.tokenString,
-      declinedPermissions: [Permission.email, .firstName],
+      declinedPermissions: [Permission.email, .userPosts],
       appID: AccessTokenFixtures.validToken.appID,
       userID: AccessTokenFixtures.validToken.userID
     )
 
-    XCTAssertEqual(token.declinedPermissions, [Permission.email, .firstName],
+    XCTAssertEqual(token.declinedPermissions, [Permission.email, .userPosts],
                    "An access token should store the exact permissions it was created with")
   }
 

--- a/Sources/Core/FacebookCoreTests/AccessTokenTests.swift
+++ b/Sources/Core/FacebookCoreTests/AccessTokenTests.swift
@@ -38,12 +38,12 @@ class AccessTokenTests: XCTestCase {
 
     let token = AccessToken(
       tokenString: AccessTokenFixtures.validToken.tokenString,
-      permissions: ["access", "more_access"],
+      permissions: [Permission.email, .firstName],
       appID: AccessTokenFixtures.validToken.appID,
       userID: AccessTokenFixtures.validToken.userID
     )
 
-    XCTAssertEqual(token.permissions, ["access", "more_access"],
+    XCTAssertEqual(token.permissions, [Permission.email, .firstName],
                    "An access token should store the exact permissions it was created with")
   }
 
@@ -52,12 +52,12 @@ class AccessTokenTests: XCTestCase {
 
     let token = AccessToken(
       tokenString: AccessTokenFixtures.validToken.tokenString,
-      declinedPermissions: ["access", "more_access"],
+      declinedPermissions: [Permission.email, .firstName],
       appID: AccessTokenFixtures.validToken.appID,
       userID: AccessTokenFixtures.validToken.userID
     )
 
-    XCTAssertEqual(token.declinedPermissions, ["access", "more_access"],
+    XCTAssertEqual(token.declinedPermissions, [Permission.email, .firstName],
                    "An access token should store the exact permissions it was created with")
   }
 
@@ -135,9 +135,9 @@ class AccessTokenTests: XCTestCase {
   func testHasGrantedPermission() {
     let token = AccessTokenFixtures.tokenWithPermissions
 
-    XCTAssertTrue(token.hasGranted(permission: "access"),
+    XCTAssertTrue(token.hasGranted(permission: .email),
                   "A token should know about its granted permissions")
-    XCTAssertFalse(token.hasGranted(permission: "all_the_access"),
+    XCTAssertFalse(token.hasGranted(permission: .publishToGroups),
                    "A token should not claim to have a permission it has not been given")
   }
 

--- a/Sources/Core/FacebookCoreTests/Fixtures/AccessTokenFixtures.swift
+++ b/Sources/Core/FacebookCoreTests/Fixtures/AccessTokenFixtures.swift
@@ -44,7 +44,7 @@ enum AccessTokenFixtures {
   static let tokenWithPermissions: AccessToken = {
     AccessToken(
       tokenString: tokenString,
-      permissions: ["access", "more_access"],
+      permissions: [Permission.email, .firstName],
       appID: appID,
       userID: userID
     )

--- a/Sources/Core/FacebookCoreTests/Fixtures/AccessTokenFixtures.swift
+++ b/Sources/Core/FacebookCoreTests/Fixtures/AccessTokenFixtures.swift
@@ -44,7 +44,7 @@ enum AccessTokenFixtures {
   static let tokenWithPermissions: AccessToken = {
     AccessToken(
       tokenString: tokenString,
-      permissions: [Permission.email, .firstName],
+      permissions: [Permission.email, .userPosts],
       appID: appID,
       userID: userID
     )

--- a/Sources/Core/FacebookCoreTests/PermissionTests.swift
+++ b/Sources/Core/FacebookCoreTests/PermissionTests.swift
@@ -16,8 +16,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// swiftlint:disable function_body_length
-
 @testable import FacebookCore
 import XCTest
 
@@ -26,14 +24,6 @@ class PermissionTests: XCTestCase {
   func testKnownCases() {
     [
       Permission.`default`,
-      .id,
-      .firstName,
-      .lastName,
-      .middleName,
-      .name,
-      .nameFormat,
-      .picture,
-      .shortName,
       .email,
       .groupsAccessMemberInfo,
       .publishToGroups,
@@ -54,14 +44,6 @@ class PermissionTests: XCTestCase {
     ].forEach { permission in
         switch permission {
         case .default,
-             .id,
-             .firstName,
-             .lastName,
-             .middleName,
-             .name,
-             .nameFormat,
-             .picture,
-             .shortName,
              .email,
              .groupsAccessMemberInfo,
              .publishToGroups,

--- a/Sources/Core/FacebookCoreTests/PermissionTests.swift
+++ b/Sources/Core/FacebookCoreTests/PermissionTests.swift
@@ -1,0 +1,89 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// swiftlint:disable function_body_length
+
+@testable import FacebookCore
+import XCTest
+
+class PermissionTests: XCTestCase {
+
+  func testKnownCases() {
+    [
+      Permission.`default`,
+      .id,
+      .firstName,
+      .lastName,
+      .middleName,
+      .name,
+      .nameFormat,
+      .picture,
+      .shortName,
+      .email,
+      .groupsAccessMemberInfo,
+      .publishToGroups,
+      .userAgeRange,
+      .userBirthday,
+      .userEvents,
+      .userFriends,
+      .userGender,
+      .userHometown,
+      .userLikes,
+      .userLink,
+      .userLocation,
+      .userMobilePhone,
+      .userPhotos,
+      .userPosts,
+      .userTaggedPlaces,
+      .userVideos
+    ].forEach { permission in
+        switch permission {
+        case .default,
+             .id,
+             .firstName,
+             .lastName,
+             .middleName,
+             .name,
+             .nameFormat,
+             .picture,
+             .shortName,
+             .email,
+             .groupsAccessMemberInfo,
+             .publishToGroups,
+             .userAgeRange,
+             .userBirthday,
+             .userEvents,
+             .userFriends,
+             .userGender,
+             .userHometown,
+             .userLikes,
+             .userLink,
+             .userLocation,
+             .userMobilePhone,
+             .userPhotos,
+             .userPosts,
+             .userTaggedPlaces,
+             .userVideos,
+             .unknown:
+          break
+      }
+    // swiftlint:disable closure_end_indentation
+    }
+    // swiftlint:enable closure_end_indentation
+  }
+}

--- a/Sources/Core/Permission.swift
+++ b/Sources/Core/Permission.swift
@@ -22,16 +22,6 @@ import Foundation
 
 enum Permission: Hashable {
   case `default`
-  // swiftlint:disable identifier_name
-  case id
-  // swiftlint:enable identifier_name
-  case firstName
-  case lastName
-  case middleName
-  case name
-  case nameFormat
-  case picture
-  case shortName
   case email
   case groupsAccessMemberInfo
   case publishToGroups

--- a/Sources/Core/Permission.swift
+++ b/Sources/Core/Permission.swift
@@ -1,0 +1,53 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Foundation
+
+// TODO: Introduce a type to JSON encode permissions This object will be responsible for translating between JSON with snake_case keys and our canonical camelCased cases
+
+enum Permission: Hashable {
+  case `default`
+  // swiftlint:disable identifier_name
+  case id
+  // swiftlint:enable identifier_name
+  case firstName
+  case lastName
+  case middleName
+  case name
+  case nameFormat
+  case picture
+  case shortName
+  case email
+  case groupsAccessMemberInfo
+  case publishToGroups
+  case userAgeRange
+  case userBirthday
+  case userEvents
+  case userFriends
+  case userGender
+  case userHometown
+  case userLikes
+  case userLink
+  case userLocation
+  case userMobilePhone
+  case userPhotos
+  case userPosts
+  case userTaggedPlaces
+  case userVideos
+  case unknown(value: String)
+}


### PR DESCRIPTION
Introduces a permissions enum with known cases.

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Introduces a Permission enum to use as the canonical type for representing permissions and declined permissions.

## Test Plan

Test Plan: Unit tests should all pass. Code coverage should remain at 100%
