### PR TITLE
Removing swiftlint version check

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,3 @@
-swiftlint_version: 0.31.0
-
 included:
   - Sources
   - Samples

--- a/Tests/Core/.swiftlint.yml
+++ b/Tests/Core/.swiftlint.yml
@@ -1,5 +1,3 @@
-swiftlint_version: 0.31.0
-
 disabled_rules:
   - closure_body_length
   - closure_end_indentation


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

HomeBrew does not allow us to specify a Swiftlint version to install. Instead it defaults to the latest version. This approach is not compatible with keeping a required version in the .swiftlint.yml since this is likely to break with new releases of Swiftlint. In short, we should not specify a required version having control over which version is installed.
