### PR TITLE
Update to support ObjC v5.2.3

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "facebook/facebook-objc-sdk" "v5.0.0"
+github "facebook/facebook-objc-sdk" "v5.2.3"


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Resolve https://github.com/facebook/facebook-swift-sdk/issues/468.
Update facebook-objc-sdk to fix build failure on Xcode 11.

## Test Plan

1. Download and setup Xcode 11
2. Build SwiftCatalog in this repository
   - Build fails without this changes
      - Error: `Implicit conversion loses integer precision: 'FBSDKAppInviteDestination' (aka 'enum FBSDKAppInviteDestination') to 'int'`
   - Build succeeds with this changes
      - This also works well with carthage build.