### PR TITLE
Updating sample project to not import dependent libraries

### DIFF
--- a/FacebookSwift.xcodeproj/project.pbxproj
+++ b/FacebookSwift.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		81D646AF1D2C8D7800690609 /* Enums+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D646821D2C8D7800690609 /* Enums+Extensions.swift */; };
 		81FC4B601D064F68003F3A46 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC4B5F1D064F68003F3A46 /* LoginManager.swift */; };
 		81FC4C981D067448003F3A46 /* Permission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC4C971D067448003F3A46 /* Permission.swift */; };
+		F4E214D823070F5F009656AE /* FBSDKCoreKit+Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E214D723070F5F009656AE /* FBSDKCoreKit+Typealiases.swift */; };
+		F4E214F0230718D4009656AE /* FBSDKLoginKit+Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E214EF230718D4009656AE /* FBSDKLoginKit+Typealiases.swift */; };
+		F4E2150A230719C4009656AE /* FBSDKShareKit+Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E21509230719C4009656AE /* FBSDKShareKit+Typealiases.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -245,6 +248,9 @@
 		81D646821D2C8D7800690609 /* Enums+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Enums+Extensions.swift"; sourceTree = "<group>"; };
 		81FC4B5F1D064F68003F3A46 /* LoginManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		81FC4C971D067448003F3A46 /* Permission.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Permission.swift; sourceTree = "<group>"; };
+		F4E214D723070F5F009656AE /* FBSDKCoreKit+Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FBSDKCoreKit+Typealiases.swift"; sourceTree = "<group>"; };
+		F4E214EF230718D4009656AE /* FBSDKLoginKit+Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FBSDKLoginKit+Typealiases.swift"; sourceTree = "<group>"; };
+		F4E21509230719C4009656AE /* FBSDKShareKit+Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FBSDKShareKit+Typealiases.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -326,9 +332,10 @@
 				810192AA1D01305400B9E881 /* AccessToken.swift */,
 				811C5E751CFFD5DD00E4A925 /* Dictionary+KeyValueMap.swift */,
 				810192A31D01305400B9E881 /* FBProfilePictureView.swift */,
+				811C5E5F1CFFD52B00E4A925 /* Internal */,
 				81FC4C971D067448003F3A46 /* Permission.swift */,
 				810192AD1D01305400B9E881 /* Settings.swift */,
-				811C5E5F1CFFD52B00E4A925 /* Internal */,
+				F4E214D723070F5F009656AE /* FBSDKCoreKit+Typealiases.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -347,6 +354,7 @@
 			children = (
 				813C9B551D1DB16F00288BFA /* FBLoginButton.swift */,
 				81FC4B5F1D064F68003F3A46 /* LoginManager.swift */,
+				F4E214EF230718D4009656AE /* FBSDKLoginKit+Typealiases.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -355,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				81D646821D2C8D7800690609 /* Enums+Extensions.swift */,
+				F4E21509230719C4009656AE /* FBSDKShareKit+Typealiases.swift */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -833,6 +842,7 @@
 				810192B71D01305400B9E881 /* Settings.swift in Sources */,
 				811C5E771CFFD5DD00E4A925 /* Dictionary+KeyValueMap.swift in Sources */,
 				810192AE1D01305400B9E881 /* FBProfilePictureView.swift in Sources */,
+				F4E214D823070F5F009656AE /* FBSDKCoreKit+Typealiases.swift in Sources */,
 				810192B41D01305400B9E881 /* AccessToken.swift in Sources */,
 				039F241E1F018FAA00489799 /* FBSDKSettingsInitializer.m in Sources */,
 				81FC4C981D067448003F3A46 /* Permission.swift in Sources */,
@@ -844,6 +854,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				813C9B561D1DB16F00288BFA /* FBLoginButton.swift in Sources */,
+				F4E214F0230718D4009656AE /* FBSDKLoginKit+Typealiases.swift in Sources */,
 				81FC4B601D064F68003F3A46 /* LoginManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -852,6 +863,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F4E2150A230719C4009656AE /* FBSDKShareKit+Typealiases.swift in Sources */,
 				81D646AF1D2C8D7800690609 /* Enums+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Samples/Catalog/Sources/AppDelegate.swift
+++ b/Samples/Catalog/Sources/AppDelegate.swift
@@ -20,7 +20,6 @@ import Foundation
 import UIKit
 
 import FacebookCore
-import FBSDKCoreKit
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -30,23 +29,26 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    FBSDKCoreKit.ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
 
     return true
   }
 
   func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-    return FBSDKCoreKit.ApplicationDelegate.shared.application(application,
-                                                               open: url,
-                                                               sourceApplication: sourceApplication,
-                                                               annotation: annotation)
+    return ApplicationDelegate.shared.application(
+      application,
+      open: url,
+      sourceApplication: sourceApplication,
+      annotation: annotation
+    )
   }
 
   @available(iOS 9.0, *)
   func application(_ application: UIApplication,
                    open url: URL,
                    options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-    return FBSDKCoreKit.ApplicationDelegate.shared.application(application, open: url, options: options)
+    return ApplicationDelegate.shared.application(application, open: url, options: options)
   }
 
   func applicationDidBecomeActive(_ application: UIApplication) {

--- a/Samples/Catalog/Sources/AppInviteViewController.swift
+++ b/Samples/Catalog/Sources/AppInviteViewController.swift
@@ -49,7 +49,11 @@ final class AppInviteViewController: UITableViewController {
     //    // Facebook hosted App Link is used here. See https://developers.facebook.com/docs/applinks for details.
     //    guard let appLink = URL(string: "https://fb.me/1539184863038815") else { return }
     //    let previewImageURL = URL(string: "http://catalogapp.parseapp.com/FacebookDeveloper.jpg")
-    //    let appInvite = AppInviteContent(appLink: appLink, deliveryMethod: .facebook, previewImageURL: previewImageURL)
+    //    let appInvite = AppInviteContent(
+    //        appLink: appLink,
+    //        deliveryMethod: .facebook,
+    //        previewImageURL: previewImageURL
+    //    )
     //    showAppInviteDialog(for: appInvite)
   }
 }

--- a/Samples/Catalog/Sources/CustomAppEventViewController.swift
+++ b/Samples/Catalog/Sources/CustomAppEventViewController.swift
@@ -17,7 +17,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import FacebookCore
-import FBSDKCoreKit
 import Foundation
 import UIKit
 

--- a/Samples/Catalog/Sources/GraphAPIPostViewController.swift
+++ b/Samples/Catalog/Sources/GraphAPIPostViewController.swift
@@ -17,7 +17,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import FacebookCore
-import FBSDKCoreKit
 import Foundation
 import UIKit
 

--- a/Samples/Catalog/Sources/GraphAPIReadViewController.swift
+++ b/Samples/Catalog/Sources/GraphAPIReadViewController.swift
@@ -20,9 +20,6 @@ import Foundation
 import UIKit
 
 import FacebookCore
-import FBSDKCoreKit
-
-// MARK: -
 
 class GraphAPIReadViewController: UITableViewController {
 

--- a/Samples/Catalog/Sources/LoginManagerViewController.swift
+++ b/Samples/Catalog/Sources/LoginManagerViewController.swift
@@ -21,7 +21,6 @@ import UIKit
 
 import FacebookCore
 import FacebookLogin
-import FBSDKLoginKit
 
 class LoginManagerViewController: UIViewController {
 

--- a/Samples/Catalog/Sources/ManualAppEventViewController.swift
+++ b/Samples/Catalog/Sources/ManualAppEventViewController.swift
@@ -17,7 +17,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import FacebookCore
-import FBSDKCoreKit
 import UIKit
 
 final class ManualAppEventViewController: UITableViewController {

--- a/Samples/Catalog/Sources/ShareAPIViewController.swift
+++ b/Samples/Catalog/Sources/ShareAPIViewController.swift
@@ -19,7 +19,6 @@
 import UIKit
 
 import FacebookShare
-import FBSDKShareKit
 
 final class ShareAPIViewController: UITableViewController, SharingDelegate {
 

--- a/Samples/Catalog/Sources/ShareDialogViewController.swift
+++ b/Samples/Catalog/Sources/ShareDialogViewController.swift
@@ -20,12 +20,11 @@ import MobileCoreServices
 import UIKit
 
 import FacebookShare
-import FBSDKShareKit
 
 final class ShareDialogViewController: UITableViewController,
   UIImagePickerControllerDelegate,
   UINavigationControllerDelegate,
-SharingDelegate {
+  SharingDelegate {
 
   func showShareDialog<C: SharingContent>(_ content: C, mode: ShareDialog.Mode = .automatic) {
     let dialog = ShareDialog(fromViewController: self, content: content, delegate: self)

--- a/Samples/Catalog/SwiftCatalog.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Samples/Catalog/SwiftCatalog.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Core/FBSDKCoreKit+Typealiases.swift
+++ b/Sources/Core/FBSDKCoreKit+Typealiases.swift
@@ -16,28 +16,15 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import FacebookLogin
+import FBSDKCoreKit
 import Foundation
-import UIKit
 
-class LoginButtonViewController: UIViewController, LoginButtonDelegate {
+// Typealiases for FBSDKCoreKit types to avoid having to import
+// dependent libraries. At somepoint these will be likely
+// become "wrapper" types that extend and enhance functionality
+// in addition to exposing it. For now it suffices to simply expose
+// them to the correct library aka. FacebookCore
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    let button = FBLoginButton(permissions: [.publicProfile])
-    button.delegate = self
-    button.center = view.center
-    view.addSubview(button)
-  }
-
-  // MARK: LoginButtonDelegate
-
-  func loginButton(_ loginButton: FBLoginButton, didCompleteWith result: LoginManagerLoginResult?, error: Error?) {
-    print("Did complete login via LoginButton with result \(String(describing: result)) " +
-      "error\(String(describing: error))")
-  }
-
-  func loginButtonDidLogOut(_ loginButton: FBLoginButton) {
-    print("Did logout via LoginButton")
-  }
-}
+public typealias ApplicationDelegate = FBSDKCoreKit.ApplicationDelegate
+public typealias AppEvents = FBSDKCoreKit.AppEvents
+public typealias GraphRequest = FBSDKCoreKit.GraphRequest

--- a/Sources/Login/FBSDKLoginKit+Typealiases.swift
+++ b/Sources/Login/FBSDKLoginKit+Typealiases.swift
@@ -16,28 +16,15 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import FacebookLogin
+import FBSDKLoginKit
 import Foundation
-import UIKit
 
-class LoginButtonViewController: UIViewController, LoginButtonDelegate {
+// Typealiases for FBSDKLoginKit types to avoid having to import
+// dependent libraries. At somepoint these will be likely
+// become "wrapper" types that extend and enhance functionality
+// in addition to exposing it. For now it suffices to simply expose
+// them to the correct library aka. FacebookLogin
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    let button = FBLoginButton(permissions: [.publicProfile])
-    button.delegate = self
-    button.center = view.center
-    view.addSubview(button)
-  }
-
-  // MARK: LoginButtonDelegate
-
-  func loginButton(_ loginButton: FBLoginButton, didCompleteWith result: LoginManagerLoginResult?, error: Error?) {
-    print("Did complete login via LoginButton with result \(String(describing: result)) " +
-      "error\(String(describing: error))")
-  }
-
-  func loginButtonDidLogOut(_ loginButton: FBLoginButton) {
-    print("Did logout via LoginButton")
-  }
-}
+public typealias LoginButtonDelegate = FBSDKLoginKit.LoginButtonDelegate
+public typealias FBLoginButton = FBSDKLoginKit.FBLoginButton
+public typealias LoginManagerLoginResult = FBSDKLoginKit.LoginManagerLoginResult

--- a/Sources/Share/FBSDKShareKit+Typealiases.swift
+++ b/Sources/Share/FBSDKShareKit+Typealiases.swift
@@ -16,28 +16,22 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import FacebookLogin
+import FBSDKShareKit
 import Foundation
-import UIKit
 
-class LoginButtonViewController: UIViewController, LoginButtonDelegate {
+// Typealiases for FBSDKShareKit types to avoid having to import
+// dependent libraries. At somepoint these will be likely
+// become "wrapper" types that extend and enhance functionality
+// in addition to exposing it. For now it suffices to simply expose
+// them to the correct library aka. FacebookShare
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    let button = FBLoginButton(permissions: [.publicProfile])
-    button.delegate = self
-    button.center = view.center
-    view.addSubview(button)
-  }
-
-  // MARK: LoginButtonDelegate
-
-  func loginButton(_ loginButton: FBLoginButton, didCompleteWith result: LoginManagerLoginResult?, error: Error?) {
-    print("Did complete login via LoginButton with result \(String(describing: result)) " +
-      "error\(String(describing: error))")
-  }
-
-  func loginButtonDidLogOut(_ loginButton: FBLoginButton) {
-    print("Did logout via LoginButton")
-  }
-}
+public typealias Sharing = FBSDKShareKit.Sharing
+public typealias ShareAPI = FBSDKShareKit.ShareAPI
+public typealias ShareDialog = FBSDKShareKit.ShareDialog
+public typealias SharingContent = FBSDKShareKit.SharingContent
+public typealias SharingDelegate = FBSDKShareKit.SharingDelegate
+public typealias ShareLinkContent = FBSDKShareKit.ShareLinkContent
+public typealias SharePhoto = FBSDKShareKit.SharePhoto
+public typealias SharePhotoContent = FBSDKShareKit.SharePhotoContent
+public typealias ShareVideo = FBSDKShareKit.ShareVideo
+public typealias ShareVideoContent = FBSDKShareKit.ShareVideoContent


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

The sample catalog was forced to pull in multiple libraries to perform basic tasks. This is a code smell that can be handled by exposing the necessary types to relevant libraries in the form of typealiases.

The downside of this approach is that it is a heavily manual process. There is a finite number of types however so this isn't the end of the world. A future PR will have a more comprehensive list accounting of the types available in the 'FBSDK' name-spaced dependencies. 

The real question is whether or not some of these types are so generically named that they should have an 'FB' prefix.

## Test Plan

Open project and build 'SwiftCatalog'