### PR TITLE
Updates LoginManager

### DIFF
--- a/FacebookSwift.xcodeproj/project.pbxproj
+++ b/FacebookSwift.xcodeproj/project.pbxproj
@@ -24,7 +24,14 @@
 		81D646AF1D2C8D7800690609 /* Enums+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D646821D2C8D7800690609 /* Enums+Extensions.swift */; };
 		81FC4B601D064F68003F3A46 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC4B5F1D064F68003F3A46 /* LoginManager.swift */; };
 		81FC4C981D067448003F3A46 /* Permission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC4C971D067448003F3A46 /* Permission.swift */; };
-		F46EC6652314BBAF00C55CA7 /* FacebookLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46EC6642314BBAF00C55CA7 /* FacebookLoginTests.swift */; };
+		F43A7E2C2315666E00591F76 /* LoginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43A7E2B2315666E00591F76 /* LoginManagerTests.swift */; };
+		F43A7E2E2315684600591F76 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43A7E2D2315684600591F76 /* AuthenticationService.swift */; };
+		F43A7E3F23156CDA00591F76 /* FakeAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43A7E3D23156CCB00591F76 /* FakeAuthenticationService.swift */; };
+		F448850F231592080000BB6C /* SampleError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F448850E231592080000BB6C /* SampleError.swift */; };
+		F4488511231592470000BB6C /* SampleAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4488510231592470000BB6C /* SampleAccessToken.swift */; };
+		F44885132315927B0000BB6C /* SampleLoginManagerLoginResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44885122315927B0000BB6C /* SampleLoginManagerLoginResult.swift */; };
+		F4488517231593580000BB6C /* LoginInformationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4488516231593580000BB6C /* LoginInformationTests.swift */; };
+		F44885192315958F0000BB6C /* LoginInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44885182315958F0000BB6C /* LoginInformation.swift */; };
 		F46EC6672314BBAF00C55CA7 /* FacebookLogin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 811C5DFD1CFFD36600E4A925 /* FacebookLogin.framework */; };
 		F46EC6742314BBBF00C55CA7 /* FacebookCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46EC6732314BBBF00C55CA7 /* FacebookCoreTests.swift */; };
 		F46EC6762314BBBF00C55CA7 /* FacebookCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8115C0D81CFE540D001FF33B /* FacebookCore.framework */; };
@@ -275,8 +282,15 @@
 		81D646821D2C8D7800690609 /* Enums+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Enums+Extensions.swift"; sourceTree = "<group>"; };
 		81FC4B5F1D064F68003F3A46 /* LoginManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		81FC4C971D067448003F3A46 /* Permission.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Permission.swift; sourceTree = "<group>"; };
+		F43A7E2B2315666E00591F76 /* LoginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManagerTests.swift; sourceTree = "<group>"; };
+		F43A7E2D2315684600591F76 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
+		F43A7E3D23156CCB00591F76 /* FakeAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeAuthenticationService.swift; sourceTree = "<group>"; };
+		F448850E231592080000BB6C /* SampleError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleError.swift; sourceTree = "<group>"; };
+		F4488510231592470000BB6C /* SampleAccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleAccessToken.swift; sourceTree = "<group>"; };
+		F44885122315927B0000BB6C /* SampleLoginManagerLoginResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleLoginManagerLoginResult.swift; sourceTree = "<group>"; };
+		F4488516231593580000BB6C /* LoginInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInformationTests.swift; sourceTree = "<group>"; };
+		F44885182315958F0000BB6C /* LoginInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInformation.swift; sourceTree = "<group>"; };
 		F46EC6622314BBAE00C55CA7 /* FacebookLoginTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FacebookLoginTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		F46EC6642314BBAF00C55CA7 /* FacebookLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookLoginTests.swift; sourceTree = "<group>"; };
 		F46EC6662314BBAF00C55CA7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F46EC6712314BBBF00C55CA7 /* FacebookCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FacebookCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F46EC6732314BBBF00C55CA7 /* FacebookCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookCoreTests.swift; sourceTree = "<group>"; };
@@ -419,6 +433,8 @@
 				813C9B551D1DB16F00288BFA /* FBLoginButton.swift */,
 				81FC4B5F1D064F68003F3A46 /* LoginManager.swift */,
 				F4E214EF230718D4009656AE /* FBSDKLoginKit+Typealiases.swift */,
+				F43A7E2D2315684600591F76 /* AuthenticationService.swift */,
+				F44885182315958F0000BB6C /* LoginInformation.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -546,6 +562,24 @@
 			name = ObjC;
 			sourceTree = "<group>";
 		};
+		F44885142315929F0000BB6C /* Samples */ = {
+			isa = PBXGroup;
+			children = (
+				F448850E231592080000BB6C /* SampleError.swift */,
+				F4488510231592470000BB6C /* SampleAccessToken.swift */,
+				F44885122315927B0000BB6C /* SampleLoginManagerLoginResult.swift */,
+			);
+			path = Samples;
+			sourceTree = "<group>";
+		};
+		F4488515231592BD0000BB6C /* Fakes */ = {
+			isa = PBXGroup;
+			children = (
+				F43A7E3D23156CCB00591F76 /* FakeAuthenticationService.swift */,
+			);
+			path = Fakes;
+			sourceTree = "<group>";
+		};
 		F46EC65A2314BB5700C55CA7 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -559,8 +593,11 @@
 		F46EC6632314BBAF00C55CA7 /* FacebookLoginTests */ = {
 			isa = PBXGroup;
 			children = (
-				F46EC6642314BBAF00C55CA7 /* FacebookLoginTests.swift */,
 				F46EC6662314BBAF00C55CA7 /* Info.plist */,
+				F43A7E2B2315666E00591F76 /* LoginManagerTests.swift */,
+				F4488515231592BD0000BB6C /* Fakes */,
+				F44885142315929F0000BB6C /* Samples */,
+				F4488516231593580000BB6C /* LoginInformationTests.swift */,
 			);
 			path = FacebookLoginTests;
 			sourceTree = "<group>";
@@ -1045,9 +1082,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F44885192315958F0000BB6C /* LoginInformation.swift in Sources */,
 				813C9B561D1DB16F00288BFA /* FBLoginButton.swift in Sources */,
 				F4E214F0230718D4009656AE /* FBSDKLoginKit+Typealiases.swift in Sources */,
 				81FC4B601D064F68003F3A46 /* LoginManager.swift in Sources */,
+				F43A7E2E2315684600591F76 /* AuthenticationService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1064,7 +1103,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F46EC6652314BBAF00C55CA7 /* FacebookLoginTests.swift in Sources */,
+				F448850F231592080000BB6C /* SampleError.swift in Sources */,
+				F43A7E3F23156CDA00591F76 /* FakeAuthenticationService.swift in Sources */,
+				F4488517231593580000BB6C /* LoginInformationTests.swift in Sources */,
+				F44885132315927B0000BB6C /* SampleLoginManagerLoginResult.swift in Sources */,
+				F43A7E2C2315666E00591F76 /* LoginManagerTests.swift in Sources */,
+				F4488511231592470000BB6C /* SampleAccessToken.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1255,8 +1299,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = FacebookLoginTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				INFOPLIST_FILE = Tests/FacebookLoginTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1311,8 +1355,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = FacebookLoginTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				INFOPLIST_FILE = Tests/FacebookLoginTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1372,8 +1416,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = FacebookCoreTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				INFOPLIST_FILE = Tests/FacebookCoreTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1428,8 +1472,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = FacebookCoreTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				INFOPLIST_FILE = Tests/FacebookCoreTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1489,8 +1533,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = FacebookShareTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				INFOPLIST_FILE = Tests/FacebookShareTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1545,8 +1589,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = FacebookShareTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				INFOPLIST_FILE = Tests/FacebookShareTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;

--- a/FacebookSwift.xcodeproj/project.pbxproj
+++ b/FacebookSwift.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		81FC4C981D067448003F3A46 /* Permission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC4C971D067448003F3A46 /* Permission.swift */; };
 		F43A7E2C2315666E00591F76 /* LoginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43A7E2B2315666E00591F76 /* LoginManagerTests.swift */; };
 		F43A7E2E2315684600591F76 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43A7E2D2315684600591F76 /* AuthenticationService.swift */; };
-		F43A7E3F23156CDA00591F76 /* FakeAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43A7E3D23156CCB00591F76 /* FakeAuthenticationService.swift */; };
+		F43A7E3F23156CDA00591F76 /* AuthenticationServiceSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43A7E3D23156CCB00591F76 /* AuthenticationServiceSpy.swift */; };
 		F448850F231592080000BB6C /* SampleError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F448850E231592080000BB6C /* SampleError.swift */; };
 		F4488511231592470000BB6C /* SampleAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4488510231592470000BB6C /* SampleAccessToken.swift */; };
 		F44885132315927B0000BB6C /* SampleLoginManagerLoginResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44885122315927B0000BB6C /* SampleLoginManagerLoginResult.swift */; };
@@ -284,7 +284,7 @@
 		81FC4C971D067448003F3A46 /* Permission.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Permission.swift; sourceTree = "<group>"; };
 		F43A7E2B2315666E00591F76 /* LoginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManagerTests.swift; sourceTree = "<group>"; };
 		F43A7E2D2315684600591F76 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
-		F43A7E3D23156CCB00591F76 /* FakeAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeAuthenticationService.swift; sourceTree = "<group>"; };
+		F43A7E3D23156CCB00591F76 /* AuthenticationServiceSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceSpy.swift; sourceTree = "<group>"; };
 		F448850E231592080000BB6C /* SampleError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleError.swift; sourceTree = "<group>"; };
 		F4488510231592470000BB6C /* SampleAccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleAccessToken.swift; sourceTree = "<group>"; };
 		F44885122315927B0000BB6C /* SampleLoginManagerLoginResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleLoginManagerLoginResult.swift; sourceTree = "<group>"; };
@@ -572,12 +572,12 @@
 			path = Samples;
 			sourceTree = "<group>";
 		};
-		F4488515231592BD0000BB6C /* Fakes */ = {
+		F4488515231592BD0000BB6C /* Spies */ = {
 			isa = PBXGroup;
 			children = (
-				F43A7E3D23156CCB00591F76 /* FakeAuthenticationService.swift */,
+				F43A7E3D23156CCB00591F76 /* AuthenticationServiceSpy.swift */,
 			);
-			path = Fakes;
+			path = Spies;
 			sourceTree = "<group>";
 		};
 		F46EC65A2314BB5700C55CA7 /* Tests */ = {
@@ -595,7 +595,7 @@
 			children = (
 				F46EC6662314BBAF00C55CA7 /* Info.plist */,
 				F43A7E2B2315666E00591F76 /* LoginManagerTests.swift */,
-				F4488515231592BD0000BB6C /* Fakes */,
+				F4488515231592BD0000BB6C /* Spies */,
 				F44885142315929F0000BB6C /* Samples */,
 				F4488516231593580000BB6C /* LoginInformationTests.swift */,
 			);
@@ -1104,7 +1104,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F448850F231592080000BB6C /* SampleError.swift in Sources */,
-				F43A7E3F23156CDA00591F76 /* FakeAuthenticationService.swift in Sources */,
+				F43A7E3F23156CDA00591F76 /* AuthenticationServiceSpy.swift in Sources */,
 				F4488517231593580000BB6C /* LoginInformationTests.swift in Sources */,
 				F44885132315927B0000BB6C /* SampleLoginManagerLoginResult.swift in Sources */,
 				F43A7E2C2315666E00591F76 /* LoginManagerTests.swift in Sources */,

--- a/FacebookSwift.xcodeproj/xcshareddata/xcschemes/FacebookLogin.xcscheme
+++ b/FacebookSwift.xcodeproj/xcshareddata/xcschemes/FacebookLogin.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F46EC6612314BBAE00C55CA7"
+               BuildableName = "FacebookLoginTests.xctest"
+               BlueprintName = "FacebookLoginTests"
+               ReferencedContainer = "container:FacebookSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "811C5DF21CFFD36600E4A925"
+            BuildableName = "FacebookLogin.framework"
+            BlueprintName = "FacebookLogin"
+            ReferencedContainer = "container:FacebookSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/Samples/Catalog/Sources/LoginManagerViewController.swift
+++ b/Samples/Catalog/Sources/LoginManagerViewController.swift
@@ -27,13 +27,33 @@ class LoginManagerViewController: UIViewController {
   func loginManagerDidComplete(_ result: LoginResult) {
     let alertController: UIAlertController
     switch result {
-    case .cancelled:
-      alertController = UIAlertController(title: "Login Cancelled", message: "User cancelled login.")
-    case .failed(let error):
-      alertController = UIAlertController(title: "Login Fail", message: "Login failed with error \(error)")
-    case .success(let grantedPermissions, _, _):
-      alertController = UIAlertController(title: "Login Success",
-                                          message: "Login succeeded with granted permissions: \(grantedPermissions)")
+    case .success(let loginInformation):
+      alertController = UIAlertController(
+        title: "Login Success",
+        message: "Login succeeded with granted permissions: \(loginInformation.grantedPermissions)"
+      )
+
+    case .failure(let error as LoginManager.LoginManagerError):
+      switch error {
+      case .cancelled:
+        alertController = UIAlertController(title: "Login Cancelled", message: "User cancelled login.")
+      case .missingAccessToken:
+        alertController = UIAlertController(
+          title: "Missing Access Token",
+          message: "The response from the server was missing an access token"
+        )
+      case .missingResult:
+        alertController = UIAlertController(
+          title: "Missing Result",
+          message: "The response from the server was missing information"
+        )
+      }
+
+    case .failure(let error):
+      alertController = UIAlertController(
+        title: "Error",
+        message: "Received unexpected error: \(error)"
+      )
     }
     self.present(alertController, animated: true, completion: nil)
   }

--- a/Sources/Login/AuthenticationService.swift
+++ b/Sources/Login/AuthenticationService.swift
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import FacebookCore
+import UIKit
+
+/**
+ Describes a service that can perform authentication, mirrors the public API of `FBSDKLoginKit.LoginManager`
+
+ - See: [FBSDKLoginKit.LoginManager](x-source-tag://FBSDKLoginKit.LoginManager)
+ */
+protocol AuthenticationServicing {
+  var loginBehavior: LoginBehavior { get set }
+  var defaultAudience: DefaultAudience { get set }
+  var authType: LoginAuthType { get set }
+
+  func logIn(
+    permissions: [String],
+    from fromViewController: UIViewController?,
+    handler: LoginManagerLoginResultBlock?
+  )
+
+  func reauthorizeDataAccess(
+    from fromViewController: UIViewController,
+    handler: @escaping LoginManagerLoginResultBlock
+  )
+
+  func logOut()
+}
+
+extension FBLoginManager: AuthenticationServicing {}

--- a/Sources/Login/FBSDKLoginKit+Typealiases.swift
+++ b/Sources/Login/FBSDKLoginKit+Typealiases.swift
@@ -129,8 +129,9 @@ public typealias LoginError = FBSDKLoginKit.LoginError
  Wrapper for `FBSDKLoginKit.LoginManager`
 
  - SeeAlso: `FBSDKLoginKit.LoginManager`
+ - Tag: FBSDKLoginKit.LoginManager
  */
-public typealias LoginManager = FBSDKLoginKit.LoginManager
+typealias FBLoginManager = FBSDKLoginKit.LoginManager
 
 /**
  Wrapper for `FBSDKLoginKit.LoginManagerLoginResult`

--- a/Sources/Login/LoginInformation.swift
+++ b/Sources/Login/LoginInformation.swift
@@ -16,6 +16,26 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import XCTest
+import FacebookCore
+import Foundation
 
-class FacebookLoginTests: XCTestCase {}
+/**
+ Describes a successful response returned from a login call
+
+ Performs a sanity check on creation to disallow duplicate granted and declined permissions
+ */
+public struct LoginInformation {
+  let grantedPermissions: Set<Permission>
+  let declinedPermissions: Set<Permission>
+  let token: AccessToken
+
+  init(
+    grantedPermissions: Set<Permission>,
+    declinedPermissions: Set<Permission>,
+    token: AccessToken
+    ) {
+    self.grantedPermissions = grantedPermissions.subtracting(declinedPermissions)
+    self.declinedPermissions = declinedPermissions
+    self.token = token
+  }
+}

--- a/Sources/Login/LoginInformation.swift
+++ b/Sources/Login/LoginInformation.swift
@@ -25,9 +25,9 @@ import Foundation
  Performs a sanity check on creation to disallow duplicate granted and declined permissions
  */
 public struct LoginInformation {
-  let grantedPermissions: Set<Permission>
-  let declinedPermissions: Set<Permission>
-  let token: AccessToken
+  public let grantedPermissions: Set<Permission>
+  public let declinedPermissions: Set<Permission>
+  public let token: AccessToken
 
   init(
     grantedPermissions: Set<Permission>,

--- a/Sources/Login/LoginManager.swift
+++ b/Sources/Login/LoginManager.swift
@@ -20,36 +20,8 @@ import FacebookCore
 import Foundation
 import UIKit
 
-/// Login Result Block
-public typealias LoginResultBlock = (LoginResult) -> Void
-
-/**
- Describes the result of a login attempt.
- */
-public enum LoginResult {
-  /// User succesfully logged in. Contains granted, declined permissions and access token.
-  case success(granted: Set<Permission>, declined: Set<Permission>, token: AccessToken)
-  /// Login attempt was cancelled by the user.
-  case cancelled
-  /// Login attempt failed.
-  case failed(Error)
-
-  internal init(result: LoginManagerLoginResult?, error: Error?) {
-    guard let result = result, error == nil else {
-      self = .failed(error ?? LoginError(.unknown))
-      return
-    }
-
-    guard !result.isCancelled, let token = result.token else {
-      self = .cancelled
-      return
-    }
-
-    let granted: Set<Permission> = Set(result.grantedPermissions.map { Permission(stringLiteral: $0) })
-    let declined: Set<Permission> = Set(result.declinedPermissions.map { Permission(stringLiteral: $0) })
-    self = .success(granted: granted, declined: declined, token: token)
-  }
-}
+/// Result type for an authentication call
+public typealias LoginResult = Result<LoginInformation, Error>
 
 /**
  This class provides methods for logging the user in and out.
@@ -62,17 +34,33 @@ public enum LoginResult {
  If you are managing your own token instances outside of `AccessToken.current`, you will need to set
  `current` before calling `logIn()` to authorize further permissions on your tokens.
  */
-public extension LoginManager {
+public struct LoginManager {
+  var authenticationService: AuthenticationServicing
+
+  // Internal init that allow for mocking dependencies in unit tests
+  init(
+    authenticationService: AuthenticationServicing = FBLoginManager(),
+    loginBehavior: LoginBehavior = .browser,
+    defaultAudience: DefaultAudience = .friends
+    ) {
+    self.authenticationService = authenticationService
+    self.authenticationService.loginBehavior = loginBehavior
+    self.authenticationService.defaultAudience = defaultAudience
+  }
+
   /**
    Initialize an instance of `LoginManager.`
 
-   - parameter loginBehavior: Optional login behavior to use. Default: `.Native`.
-   - parameter defaultAudience: Optional default audience to use. Default: `.Friends`.
+   - Parameter loginBehavior: Optional login behavior to use. Default: `.native`.
+   - Parameter defaultAudience: Optional default audience to use. Default: `.friends`.
    */
-  convenience init(loginBehavior: LoginBehavior = .browser, defaultAudience: DefaultAudience = .friends) {
-    self.init()
-    self.loginBehavior = loginBehavior
-    self.defaultAudience = defaultAudience
+  public init(
+    loginBehavior: LoginBehavior = .browser,
+    defaultAudience: DefaultAudience = .friends
+    ) {
+    self.authenticationService = FBLoginManager()
+    self.authenticationService.loginBehavior = loginBehavior
+    self.authenticationService.defaultAudience = defaultAudience
   }
 
   /**
@@ -85,51 +73,84 @@ public extension LoginManager {
    This method will present UI the user. You typically should check if `AccessToken.current` already
    contains the permissions you need before asking to reduce unnecessary app switching.
 
-   - parameter permissions: Array of read permissions. Default: `[.PublicProfile]`
-   - parameter viewController: Optional view controller to present from. Default: topmost view controller.
-   - parameter completion: Optional callback.
+   - Parameter permissions: Array of read permissions. Default: `[.PublicProfile]`
+   - Parameter viewController: Optional view controller to present from. Default: topmost view controller.
+   - Parameter completion: Called with a `LoginResult` and returns Void
    */
-  func logIn(permissions: [Permission] = [.publicProfile],
-             viewController: UIViewController? = nil,
-             completion: LoginResultBlock? = nil) {
-    self.logIn(permissions: permissions.map { $0.name }, from: viewController, handler: sdkCompletion(completion))
-  }
-
-  struct LoginResultData {
-    let granted: Set<Permission>
-    let declined: Set<Permission>
-    let token: AccessToken
-  }
-
-  func logIn(
+  public func logIn(
     permissions: [Permission] = [.publicProfile],
     viewController: UIViewController? = nil,
-    completion: ((Result<LoginResultData, Error>) -> Void)? = nil
+    completion: @escaping ((LoginResult) -> Void)
     ) {
-    logIn(permissions: permissions.map { $0.name }, from: viewController) { (loginManagerResult, error) in
-      guard let grantedPermissions = loginManagerResult?.grantedPermissions.compactMap({ Permission(stringLiteral: $0) }),
-        let declinedPermissions = loginManagerResult?.declinedPermissions.compactMap({ Permission(stringLiteral: $0) }),
-        let token = loginManagerResult?.token else {
-          completion?(.failure(NSError()))
-          return
+    authenticationService.logIn(
+      permissions: permissions.map { $0.name },
+      from: viewController
+    ) { loginManagerResult, error in
+      if let error = error {
+        return completion(.failure(error))
       }
 
-      let data = LoginResultData(
-        granted: Set(grantedPermissions),
-        declined: Set(declinedPermissions),
+      guard let loginManagerResult = loginManagerResult else {
+        return completion(.failure(LoginManagerError.missingResult))
+      }
+
+      guard !loginManagerResult.isCancelled else {
+        return completion(.failure(LoginManagerError.cancelled))
+      }
+
+      guard let token = loginManagerResult.token else {
+        return completion(.failure(LoginManagerError.missingAccessToken))
+      }
+
+      let grantedPermissions = Set(loginManagerResult.grantedPermissions.compactMap { Permission(stringLiteral: $0) })
+      let declinedPermissions = Set(loginManagerResult.declinedPermissions.compactMap { Permission(stringLiteral: $0) })
+
+      let info = LoginInformation(
+        grantedPermissions: grantedPermissions,
+        declinedPermissions: declinedPermissions,
         token: token
       )
-      completion?(.success(data))
+
+      completion(.success(info))
     }
   }
 
-  private func sdkCompletion(_ completion: LoginResultBlock?) -> LoginManagerLoginResultBlock? {
-    guard let completion = completion else {
-      return nil
-    }
-    return { (result: LoginManagerLoginResult?, error: Error?) in
-      let result = LoginResult(result: result, error: error)
-      completion(result)
-    }
+  /**
+   Requests user's permission to reathorize application's data access, after it has expired due to inactivity.
+
+   - Parameter fromViewController: the view controller to present from. If nil, the topmost view controller will be
+   automatically determined as best as possible.
+   - Parameter handler: the callback.
+
+   Use this method when you need to reathorize your app's access to user data via Graph API,
+   after such an access has expired.
+   You should provide as much context to the user as possible as to why you need to reauthorize the access,
+   the scope of access being reathorized, and what added value your app provides when the access is reathorized.
+   You can inspect the result.declinedPermissions to also provide more information to the user if they decline
+   permissions.
+   This method will present UI the user.
+   You typically should call this if `AccessToken.isDataAccessExpired` returns true.
+   */
+  func reauthorizeDataAccess(
+    from viewController: UIViewController,
+    handler: @escaping LoginManagerLoginResultBlock
+    ) {
+    authenticationService.reauthorizeDataAccess(from: viewController, handler: handler)
+  }
+
+  /**
+   Logs the user out
+
+   This sets the currently stored access token to nil and sets the currently stored user profile to nil.
+   */
+  func logOut() {
+    authenticationService.logOut()
+  }
+
+  /// Describes Errors related to Facebook authentication
+  public enum LoginManagerError: Error {
+    case missingResult
+    case missingAccessToken
+    case cancelled
   }
 }

--- a/Sources/Login/LoginManager.swift
+++ b/Sources/Login/LoginManager.swift
@@ -131,7 +131,7 @@ public struct LoginManager {
    This method will present UI the user.
    You typically should call this if `AccessToken.isDataAccessExpired` returns true.
    */
-  func reauthorizeDataAccess(
+  public func reauthorizeDataAccess(
     from viewController: UIViewController,
     handler: @escaping LoginManagerLoginResultBlock
     ) {
@@ -143,7 +143,7 @@ public struct LoginManager {
 
    This sets the currently stored access token to nil and sets the currently stored user profile to nil.
    */
-  func logOut() {
+  public func logOut() {
     authenticationService.logOut()
   }
 

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,19 +1,3 @@
-included:
-  - Sources
-  - Samples
-  - Tests
-
-excluded:
-  - Pods
-  - Carthage
-  - Carthage/facebook-objc-sdk/samples
-  - Carthage/facebook-objc-sdk/vendor
-  - Vendor
-
-cyclomatic_complexity: 11
-explicit_type_interface:
-  excluded:
-    - local
 file_header:
   required_pattern: |
     \/\/ Copyright \(c\) \d{4}-present, Facebook, Inc\. All rights reserved\.
@@ -33,16 +17,6 @@ file_header:
     \/\/ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     \/\/ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     \/\/ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE\.
-identifier_name:
-  excluded:
-    - ok
-indentation: 2
-large_tuple: 3
-line_length: 120
-nesting:
-  type_level: 2
-private_outlet:
-  allow_private_set: true
 
 disabled_rules:
   - conditional_returns_on_newline
@@ -54,12 +28,14 @@ disabled_rules:
   - number_separator
   - prefixed_toplevel_constant
   - switch_case_on_newline
-  - file_name
   # TODO: All below to move to Opt In
   - discouraged_optional_boolean
   - discouraged_optional_collection
   - function_default_parameter_at_end
   - todo
+  - force_cast
+  - force_try
+  - implicitly_unwrapped_optional
 
 opt_in_rules:
   - array_init

--- a/Tests/FacebookLoginTests/Fakes/FakeAuthenticationService.swift
+++ b/Tests/FacebookLoginTests/Fakes/FakeAuthenticationService.swift
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@testable import FacebookLogin
+import UIKit
+
+class FakeAuthenticationService: AuthenticationServicing {
+  var authType: LoginAuthType = .rerequest
+  var loginBehavior: LoginBehavior = .browser
+  var defaultAudience: DefaultAudience = .friends
+
+  var capturedLoginPermissions = [String]()
+  var capturedFromViewController: UIViewController?
+  var capturedLogInHandler: LoginManagerLoginResultBlock?
+
+  func logIn(
+    permissions: [String],
+    from fromViewController: UIViewController?,
+    handler: LoginManagerLoginResultBlock?
+    ) {
+    capturedLoginPermissions = permissions
+    capturedFromViewController = fromViewController
+    capturedLogInHandler = handler
+  }
+
+  func reauthorizeDataAccess(
+    from fromViewController: UIViewController,
+    handler: @escaping LoginManagerLoginResultBlock
+    ) {
+    // TODO: implement
+  }
+
+  func logOut() {
+    // TODO: implement
+  }
+}

--- a/Tests/FacebookLoginTests/LoginInformationTests.swift
+++ b/Tests/FacebookLoginTests/LoginInformationTests.swift
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@testable import FacebookLogin
+import XCTest
+
+class LoginInformationTests: XCTestCase {
+  func testCreatingWithSingleConflictingPermissions() {
+    let info = LoginInformation(
+      grantedPermissions: ["foo"],
+      declinedPermissions: ["foo"],
+      token: SampleAccessToken.valid
+    )
+
+    XCTAssertTrue(info.grantedPermissions.isEmpty,
+                  "Granted permissions should be cancelled out by duplicate declined permissions")
+    XCTAssertEqual(info.declinedPermissions, Set(["foo"]),
+                   "Declined permissions should remain regardless of duplicates in granted permissions")
+  }
+
+  func testCreatingWithMultipleConflictingPermissions() {
+    let info = LoginInformation(
+      grantedPermissions: ["foo", "bar", "baz"],
+      declinedPermissions: ["foo", "bar", "baz"],
+      token: SampleAccessToken.valid
+    )
+
+    XCTAssertTrue(info.grantedPermissions.isEmpty,
+                  "Granted permissions should be cancelled out by duplicate declined permissions")
+    XCTAssertEqual(info.declinedPermissions, Set(["foo", "bar", "baz"]),
+                   "Declined permissions should remain regardless of duplicates in granted permissions")
+  }
+
+  func testCreatingWithConflictingAndUniquePermissions() {
+    let info = LoginInformation(
+      grantedPermissions: ["abc", "foo", "bar", "baz"],
+      declinedPermissions: ["abc", "def", "ghi"],
+      token: SampleAccessToken.valid
+    )
+
+    XCTAssertEqual(info.grantedPermissions, Set(["foo", "bar", "baz"]),
+                   "Granted permissions that are not duplicated in declined permissions should remain granted")
+    XCTAssertEqual(info.declinedPermissions, Set(["abc", "def", "ghi"]),
+                   "Declined permissions should remain regardless of duplicates in granted permissions")
+  }
+}

--- a/Tests/FacebookLoginTests/LoginManagerTests.swift
+++ b/Tests/FacebookLoginTests/LoginManagerTests.swift
@@ -21,14 +21,14 @@
 import XCTest
 
 class LoginManagerTests: XCTestCase {
-  var fakeAuthenticationService: FakeAuthenticationService!
+  var authenticationServiceSpy: AuthenticationServiceSpy!
   var manager: LoginManager!
 
   override func setUp() {
     super.setUp()
 
-    fakeAuthenticationService = FakeAuthenticationService()
-    manager = LoginManager(authenticationService: fakeAuthenticationService)
+    authenticationServiceSpy = AuthenticationServiceSpy()
+    manager = LoginManager(authenticationService: authenticationServiceSpy)
   }
 
   func testAuthenticationServiceDependency() {
@@ -80,7 +80,7 @@ class LoginManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    fakeAuthenticationService.capturedLogInHandler?(nil, SampleError())
+    authenticationServiceSpy.capturedLogInHandler?(nil, SampleError())
     wait(for: [expectation], timeout: 1)
   }
 
@@ -102,7 +102,7 @@ class LoginManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    fakeAuthenticationService.capturedLogInHandler?(nil, nil)
+    authenticationServiceSpy.capturedLogInHandler?(nil, nil)
     wait(for: [expectation], timeout: 1)
   }
 
@@ -124,7 +124,7 @@ class LoginManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    fakeAuthenticationService.capturedLogInHandler?(
+    authenticationServiceSpy.capturedLogInHandler?(
       SampleLoginManagerLoginResult.cancelled,
       nil
     )
@@ -149,7 +149,7 @@ class LoginManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    fakeAuthenticationService.capturedLogInHandler?(
+    authenticationServiceSpy.capturedLogInHandler?(
       SampleLoginManagerLoginResult.missingAccessToken,
       nil
     )
@@ -173,7 +173,7 @@ class LoginManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    fakeAuthenticationService.capturedLogInHandler?(
+    authenticationServiceSpy.capturedLogInHandler?(
       SampleLoginManagerLoginResult.missingPermissions,
       nil
     )
@@ -197,7 +197,7 @@ class LoginManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    fakeAuthenticationService.capturedLogInHandler?(
+    authenticationServiceSpy.capturedLogInHandler?(
       SampleLoginManagerLoginResult.conflictingPermissions,
       nil
     )
@@ -229,7 +229,7 @@ class LoginManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    fakeAuthenticationService.capturedLogInHandler?(
+    authenticationServiceSpy.capturedLogInHandler?(
       serviceResult,
       nil
     )

--- a/Tests/FacebookLoginTests/LoginManagerTests.swift
+++ b/Tests/FacebookLoginTests/LoginManagerTests.swift
@@ -1,0 +1,238 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@testable import FacebookCore
+@testable import FacebookLogin
+import XCTest
+
+class LoginManagerTests: XCTestCase {
+  var fakeAuthenticationService: FakeAuthenticationService!
+  var manager: LoginManager!
+
+  override func setUp() {
+    super.setUp()
+
+    fakeAuthenticationService = FakeAuthenticationService()
+    manager = LoginManager(authenticationService: fakeAuthenticationService)
+  }
+
+  func testAuthenticationServiceDependency() {
+    XCTAssertTrue(LoginManager().authenticationService is FBLoginManager,
+                  "Login manager should use an underlying FBLoginManager for its authentication service")
+  }
+
+  func testCreatingWithDefaultLoginBehavior() {
+    let manager = LoginManager()
+
+    XCTAssertEqual(manager.authenticationService.loginBehavior, .browser,
+                   "Should use the expected default login behavior")
+  }
+
+  func testCreatingWithDefaultAudience() {
+    let manager = LoginManager()
+
+    XCTAssertEqual(manager.authenticationService.defaultAudience, .friends,
+                   "Should use the expected default login audience")
+  }
+
+  func testCreatingWithCustomAudience() {
+    let manager = LoginManager(defaultAudience: .everyone)
+
+    XCTAssertEqual(manager.authenticationService.defaultAudience, .everyone,
+                   "Should be able to set a default audience for the authentication service to use")
+  }
+
+  func testLogInWithLoginError() {
+    // TODO: Add support for converting NSError's with known codes to a LoginError type
+    // that  is more than just an extension of NSError
+  }
+
+  func testLogInWithUnknownError() {
+    let expectation = self.expectation(description: name)
+
+    manager.logIn { result in
+      switch result {
+      case .success:
+        XCTFail("A response with an error should not be considered a success")
+
+      case .failure(let error as SampleError):
+        XCTAssertEqual(error, SampleError(),
+                       "Should pass back the error received from the service call")
+
+      case .failure(let error):
+        XCTFail("Should only receive known errors, received: \(error)")
+      }
+      expectation.fulfill()
+    }
+
+    fakeAuthenticationService.capturedLogInHandler?(nil, SampleError())
+    wait(for: [expectation], timeout: 1)
+  }
+
+  func testLogInWithMissingResult() {
+    let expectation = self.expectation(description: name)
+
+    manager.logIn { result in
+      switch result {
+      case .success:
+        XCTFail("A response with a missing result should not be considered a success")
+
+      case .failure(let error as LoginManager.LoginManagerError):
+        XCTAssertEqual(error, .missingResult,
+                       "Should throw a meaningful error for a missing result")
+
+      case .failure(let error):
+        XCTFail("Should only receive known errors, received: \(error)")
+      }
+      expectation.fulfill()
+    }
+
+    fakeAuthenticationService.capturedLogInHandler?(nil, nil)
+    wait(for: [expectation], timeout: 1)
+  }
+
+  func testLogInWithCancelledResult() {
+    let expectation = self.expectation(description: name)
+
+    manager.logIn { result in
+      switch result {
+      case .success:
+        XCTFail("A response with a cancelled result should not be considered a success")
+
+      case .failure(let error as LoginManager.LoginManagerError):
+        XCTAssertEqual(error, .cancelled,
+                       "Should throw a meaningful error for a cancelled result")
+
+      case .failure(let error):
+        XCTFail("Should only receive known errors, received: \(error)")
+      }
+      expectation.fulfill()
+    }
+
+    fakeAuthenticationService.capturedLogInHandler?(
+      SampleLoginManagerLoginResult.cancelled,
+      nil
+    )
+    wait(for: [expectation], timeout: 1)
+  }
+
+  func testLogInWithMissingAccessToken() {
+    let expectation = self.expectation(description: name)
+
+    manager.logIn { result in
+      switch result {
+      case .success:
+        XCTFail("A response with a result that is missing an access token should not be considered a success")
+
+      case .failure(let error as LoginManager.LoginManagerError):
+        XCTAssertEqual(error, .missingAccessToken,
+                       "Should throw a meaningful error for a result that is missing an access token")
+
+      case .failure(let error):
+        XCTFail("Should only receive known errors, received: \(error)")
+      }
+      expectation.fulfill()
+    }
+
+    fakeAuthenticationService.capturedLogInHandler?(
+      SampleLoginManagerLoginResult.missingAccessToken,
+      nil
+    )
+    wait(for: [expectation], timeout: 1)
+  }
+
+  func testLogInWithoutPermissions() {
+    let expectation = self.expectation(description: name)
+
+    manager.logIn { result in
+      switch result {
+      case .success(let info):
+        XCTAssertTrue(info.grantedPermissions.isEmpty,
+                      "Should not store granted permissions if none were received")
+        XCTAssertTrue(info.declinedPermissions.isEmpty,
+                      "Should not store declined permissions if none were received")
+
+      case .failure:
+        XCTFail("A response without permissions should still be considered a success")
+      }
+      expectation.fulfill()
+    }
+
+    fakeAuthenticationService.capturedLogInHandler?(
+      SampleLoginManagerLoginResult.missingPermissions,
+      nil
+    )
+    wait(for: [expectation], timeout: 1)
+  }
+
+  func testLogInWithConflictingPermissions() {
+    let expectation = self.expectation(description: name)
+
+    manager.logIn { result in
+      switch result {
+      case .success(let info):
+        XCTAssertTrue(info.grantedPermissions.isEmpty,
+                      "Granted permissions should be cancelled out by conflicting declined permissions")
+        XCTAssertFalse(info.declinedPermissions.isEmpty,
+                       "Declined permissions should not be cancelled out by conflicting granted permissions")
+
+      case .failure:
+        XCTFail("A response with conflicting permissions should still be considered a success")
+      }
+      expectation.fulfill()
+    }
+
+    fakeAuthenticationService.capturedLogInHandler?(
+      SampleLoginManagerLoginResult.conflictingPermissions,
+      nil
+    )
+    wait(for: [expectation], timeout: 1)
+  }
+
+  func testLogInWithNonConflictingPermissions() {
+    let expectation = self.expectation(description: name)
+    let serviceResult = SampleLoginManagerLoginResult.valid
+
+    manager.logIn { result in
+      switch result {
+      case .success(let info):
+        let expectedGrantedPermissions = Set(
+          serviceResult.grantedPermissions.compactMap { Permission(stringLiteral: $0) }
+        )
+        let expectedDeclinedPermissions = Set(
+          serviceResult.declinedPermissions.compactMap { Permission(stringLiteral: $0) }
+        )
+
+        XCTAssertEqual(info.grantedPermissions, expectedGrantedPermissions,
+                       "Result should contain the granted permissions from the service")
+        XCTAssertEqual(info.declinedPermissions, expectedDeclinedPermissions,
+                       "Result should contain the declined permissions from the service")
+
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
+      expectation.fulfill()
+    }
+
+    fakeAuthenticationService.capturedLogInHandler?(
+      serviceResult,
+      nil
+    )
+    wait(for: [expectation], timeout: 1)
+  }
+}

--- a/Tests/FacebookLoginTests/Samples/SampleAccessToken.swift
+++ b/Tests/FacebookLoginTests/Samples/SampleAccessToken.swift
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@testable import FacebookCore
+import Foundation
+
+enum SampleAccessToken {
+  static let valid = AccessToken(
+    tokenString: "foo",
+    permissions: [],
+    declinedPermissions: [],
+    expiredPermissions: [],
+    appID: "abc123",
+    userID: "bar",
+    expirationDate: Date.distantFuture,
+    refreshDate: nil,
+    dataAccessExpirationDate: Date.distantFuture
+  )
+}

--- a/Tests/FacebookLoginTests/Samples/SampleError.swift
+++ b/Tests/FacebookLoginTests/Samples/SampleError.swift
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Foundation
+
+/// Used for testing errors when the specific error type is not important
+struct SampleError: Error, Equatable {}

--- a/Tests/FacebookLoginTests/Samples/SampleLoginManagerLoginResult.swift
+++ b/Tests/FacebookLoginTests/Samples/SampleLoginManagerLoginResult.swift
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@testable import FacebookLogin
+import Foundation
+
+enum SampleLoginManagerLoginResult {
+  static let cancelled = LoginManagerLoginResult(
+    token: nil,
+    isCancelled: true,
+    grantedPermissions: [],
+    declinedPermissions: []
+  )
+
+  static let missingAccessToken = LoginManagerLoginResult(
+    token: nil,
+    isCancelled: false,
+    grantedPermissions: [],
+    declinedPermissions: []
+  )
+
+  static let missingPermissions = LoginManagerLoginResult(
+    token: SampleAccessToken.valid,
+    isCancelled: false,
+    grantedPermissions: [],
+    declinedPermissions: []
+  )
+
+  static let conflictingPermissions = LoginManagerLoginResult(
+    token: SampleAccessToken.valid,
+    isCancelled: false,
+    grantedPermissions: ["foo"],
+    declinedPermissions: ["foo"]
+  )
+
+  static let valid = LoginManagerLoginResult(
+    token: SampleAccessToken.valid,
+    isCancelled: false,
+    grantedPermissions: ["friends"],
+    declinedPermissions: ["family"]
+  )
+}

--- a/Tests/FacebookLoginTests/Spies/AuthenticationServiceSpy.swift
+++ b/Tests/FacebookLoginTests/Spies/AuthenticationServiceSpy.swift
@@ -19,7 +19,7 @@
 @testable import FacebookLogin
 import UIKit
 
-class FakeAuthenticationService: AuthenticationServicing {
+class AuthenticationServiceSpy: AuthenticationServicing {
   var authType: LoginAuthType = .rerequest
   var loginBehavior: LoginBehavior = .browser
   var defaultAudience: DefaultAudience = .friends


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've ensured that my code lints properly: (`swiftlint && swiftlint autocorrect --format`)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Updates to LoginManager

**Breaking changes:**
* LoginManager is now a struct. It is a separate abstraction layer from the underlying FBSDKLoginManager implementation.
* `logIn` method signature is updated to use actual Result type
* `logIn` method signature is updated to require a completion. Fire and forget makes little sense in the context of authentication.

**Additionally:**
* Adds sanity check around returned permissions
* Adds tests around service
* Adds layer of separation between LoginManager and FBSDKLoginManager

## Test Plan

Unit tests were added and should all pass.
